### PR TITLE
add goaéls

### DIFF
--- a/app/(app)/children/index.tsx
+++ b/app/(app)/children/index.tsx
@@ -229,16 +229,22 @@ export default function Children() {
 								</View>
 								
 								{/* Épargne */}
-								<View style={styles.bubbleContainer}>
+								<TouchableOpacity 
+									style={styles.bubbleContainer}
+									onPress={() => router.push({
+										pathname: "/(app)/goals",
+										params: { childId: selectedChild.id, childName: selectedChild.name }
+									})}
+								>
 									<View style={styles.bubleTitleContainer}>
-									<View style={[styles.bubbleIconBadge, {backgroundColor: "#FEA0BA66"}]}>
+										<View style={[styles.bubbleIconBadge, {backgroundColor: "#FEA0BA66"}]}>
 											<Ionicons name="cash-outline" size={20} color="#FD618C" style={styles.bubbleIcon} />
 										</View>
 										<Text style={styles.bubleTitle}>Épargne</Text>
 									</View>
 									<Text style={styles.bubleDescription}>{selectedChild.money?.toString() ?? "0"}€</Text>
 									<Text style={styles.bubleText}>Voir détails</Text>
-								</View>
+								</TouchableOpacity>
 							</View>
 							<View style={styles.bubble}>
 								{/* Revenus */}

--- a/app/(app)/goals/_layout.tsx
+++ b/app/(app)/goals/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function GoalsLayout() {
+	return (
+		<Stack screenOptions={{ headerShown: false }}>
+			<Stack.Screen name="index" />
+		</Stack>
+	);
+}

--- a/app/(app)/goals/index.tsx
+++ b/app/(app)/goals/index.tsx
@@ -1,0 +1,175 @@
+import { goalsService } from "@/services/goalService";
+import { Ionicons } from "@expo/vector-icons"
+import { Goal } from "@/types/Goal";
+import { useEffect, useState } from "react";
+import { SafeAreaView, ScrollView, StyleSheet, RefreshControl, View, Text, TouchableOpacity, ActivityIndicator } from "react-native"
+import { router, useLocalSearchParams } from "expo-router";
+import GoalCard from "@/components/GoalCard";
+
+const GoalPage = () => {
+    const { childId, childName } = useLocalSearchParams<{ childId: string; childName: string }>()
+    
+    const [refreshing, setRefreshing] = useState(false);
+    const [loading, setLoading] = useState(false)
+    
+    const [goals, setGoals] = useState<Goal[]>([])
+
+    const totalAmount = goals
+    .reduce((sum, i) => sum + (i.amount ?? 0), 0)
+
+    const loadData = async () => {
+        if (!childId) return
+        try {
+            const goals = await goalsService.getAllGoals({ childId })
+            setGoals(goals)
+        } catch (error) {
+            console.error("Erreur chargement goals:", error)
+        } finally {
+            setLoading(false)
+            setRefreshing(false)
+        }
+    }
+    
+    const onRefresh = () => {
+        setRefreshing(true)
+        loadData()
+    }
+
+    useEffect(() => {
+        loadData()
+    }, [])
+
+    if (loading) {
+        return (
+            <SafeAreaView style={styles.container}>
+                <View style={styles.loadingContainer}>
+                    <ActivityIndicator size="large" color="#846DED" />
+                </View>
+            </SafeAreaView>
+        )
+    }
+
+
+    return (
+        <SafeAreaView style={styles.container}>
+            
+            {/* Header */}
+            <View style={styles.header}>
+                <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+                    <Ionicons name="arrow-back" size={18} color="#fff" />
+                </TouchableOpacity>
+                <Text style={styles.headerTitle}>Épargne de {childName}</Text>
+                <Text style={styles.amountText}>
+                    {totalAmount.toFixed(2)}€
+                </Text>
+            </View>
+
+            {/* Hero */}
+            <View style={styles.heroContainer}>
+                <Text>{childName} a économisé {totalAmount.toFixed(2)} ce mois-ci ! 🥳</Text>
+            </View>
+
+            {/* Content */}
+            <ScrollView
+                style={styles.scrollView}
+                showsVerticalScrollIndicator={false}
+                refreshControl={
+                    <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#846DED" />
+                }
+            >
+                {goals?.length > 0 ? 
+                    <View style={styles.goalCardList}>
+                        {goals.map((goal) => <View key={goal.id} ><GoalCard goal={goal} /></View>) }
+                    </View>:
+                    <View>
+                        <Text>Aidez-le à comprendre comment son argent grandit en créant un objectif.</Text>
+                    </View>
+                }
+            </ScrollView>
+                
+                
+        </SafeAreaView>
+    )
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: "#f8f9fa",
+	},
+    loadingContainer: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+
+    // Header
+    header: {
+        flexDirection: "column",
+        alignItems: "flex-start",
+        paddingHorizontal: 20,
+        paddingVertical: 16,
+        backgroundColor: "#fff",
+        borderBottomWidth: 1,
+        borderBottomColor: "#F0F0F0",
+        gap: 14,
+    },
+    backButton: {
+        backgroundColor: "#2F2F2F",
+        borderRadius: 8,
+        padding: 12,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    headerTitle: {
+        fontFamily: "DMSans_700Bold",
+        fontSize: 18,
+        color: "#2F2F2F",
+    },
+
+    // ScrollView
+    scrollView: {
+        flex: 1,
+        backgroundColor: "#ECF2FB",
+        paddingHorizontal: 20,
+        paddingVertical: 10
+    },
+
+    // Amount Section
+    amountText: {
+        fontSize: 40,
+        color: "#2F2F2F",
+        lineHeight: 56,
+    },
+    amountSubtitle: {
+        fontFamily: "DMSans_400Regular",
+        fontSize: 14,
+        color: "#828282",
+        marginTop: 4,
+    },
+
+    // Hero Section
+    heroContainer: {
+        backgroundColor: "#FFFFFF",
+        borderBottomWidth: 1,
+        borderBottomColor: "#F0F0F0",
+        paddingHorizontal: 20,
+        paddingVertical: 16,
+    },
+
+    //GoalCard
+    goalCardList: {
+        display: "flex",
+        flexDirection: "column",
+        gap: 15
+    },
+
+    //No Goals
+    noGoalsContainer: {
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center"
+    }
+})
+
+export default GoalPage

--- a/components/CircualProgress.tsx
+++ b/components/CircualProgress.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef } from "react";
+import { View, Text, StyleSheet, Animated } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+type IProps = {
+    size?: number
+    strokeWidth?: number
+    progress?: number
+    color?: string
+    trackColor?: string
+}
+
+const CircularProgress = ({
+    size = 88,
+    strokeWidth = 9,
+    progress = 0,
+    color = "#F06C8A",
+    trackColor = "#EBEBEB",
+  }: IProps) => {
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const cx = size / 2;
+    const cy = size / 2;
+  
+    const animOffset = useRef(new Animated.Value(circumference)).current;
+  
+    useEffect(() => {
+      const clamped = Math.min(100, Math.max(0, progress));
+      const targetOffset = circumference * (1 - clamped / 100);
+  
+      Animated.timing(animOffset, {
+        toValue: targetOffset,
+        duration: 900,
+        delay: 100,
+        useNativeDriver: false,
+      }).start();
+    }, [progress]);
+  
+    return (
+      <View style={{ width: size, height: size }}>
+        <Svg width={size} height={size}>
+          {/* Piste de fond */}
+          <Circle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            stroke={trackColor}
+            strokeWidth={strokeWidth}
+            fill="none"
+          />
+          {/* Arc de progression — part du haut (−90°) */}
+          <AnimatedCircle
+            cx={cx}
+            cy={cy}
+            r={radius}
+            stroke={color}
+            strokeWidth={strokeWidth}
+            fill="none"
+            strokeDasharray={circumference}
+            strokeDashoffset={animOffset}
+            strokeLinecap="round"
+            rotation="-90"
+            origin={`${cx}, ${cy}`}
+          />
+        </Svg>
+  
+        {/* Pourcentage centré */}
+        <View style={[StyleSheet.absoluteFill, styles.percentCenter]}>
+          <Text style={styles.percentText}>{Math.round(progress)}%</Text>
+        </View>
+      </View>
+    );
+}
+
+const styles = StyleSheet.create({
+  percentCenter: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  percentText: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#111",
+  },
+})
+
+export default CircularProgress

--- a/components/GoalCard.tsx
+++ b/components/GoalCard.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { View, Text, StyleSheet, Animated } from "react-native";
+import CircularProgress from "./CircualProgress";
+import { Goal } from "@/types/Goal";
+import getRandomColor from "@/utils/fn/getRandomColor";
+
+type IProps = {
+    goal: Goal
+    backgroundIconColor?: string
+}
+
+export default function GoalCard({goal, backgroundIconColor = getRandomColor()} : IProps) {
+    const {amount, emoji, name, progression} = goal
+  const formattedAmount = amount.toLocaleString("fr-FR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.left}>
+        <View style={[styles.iconWrapper, { backgroundColor: backgroundIconColor }]}>
+          <Text style={styles.iconEmoji}>{emoji ?? "🦸"}</Text>
+        </View>
+
+        <View style={styles.textBlock}>
+          <Text style={styles.title} numberOfLines={2}>
+            {name}
+          </Text>
+          <Text style={styles.amount}>
+            {formattedAmount}€
+          </Text>
+        </View>
+      </View>
+
+      <CircularProgress
+        progress={progression}
+        color={"#F06C8A"}
+        size={88}
+        strokeWidth={12}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 4,
+    padding: 12,
+    shadowColor: "#BFD0EA",
+    shadowOffset: { width: 0, height: 3.89 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    elevation: 4,
+  },
+  left: {
+    flexDirection: "column",
+    alignItems: "flex-start",
+    flex: 1,
+    marginRight: 16,
+    gap: 8,
+  },
+  iconWrapper: {
+    width: 52,
+    height: 52,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconEmoji: {
+    fontSize: 26,
+  },
+  textBlock: {
+    flexShrink: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#2F2F2F",
+    marginBottom: 2,
+  },
+  amount: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: "#2F2F2F",
+    letterSpacing: -0.5,
+  },
+});

--- a/services/goalService.ts
+++ b/services/goalService.ts
@@ -1,0 +1,28 @@
+import { Goal, GoalStatus } from "@/types/Goal";
+import { apiService } from "./api";
+
+
+type GetGoalParams = {
+    childId?: string;
+    status?: GoalStatus
+    type?: string;
+}
+
+export const goalsService = { 
+
+    async getAllGoals(params: GetGoalParams): Promise<Goal[]> {
+		const { childId, status, type } = params;
+		const queryParams = new URLSearchParams();
+
+		if (childId)
+			queryParams.append('childId', childId);
+		
+		if (status)
+			queryParams.append('status', status);
+		
+		if (type)
+			queryParams.append('type', type);
+
+		return apiService.get<Goal[]>(`/goals?${queryParams.toString()}`);
+	},
+}

--- a/types/Goal.ts
+++ b/types/Goal.ts
@@ -1,0 +1,23 @@
+
+
+export enum GoalStatus {
+    ACTIVATED = "ACTIVATED",
+    DONE = "DONE",
+    USED = "USED"
+}
+
+export type Goal = {
+    id: string
+    subaccountIdChild: string
+    accountId: string
+    
+    name: string
+    amount: number
+    emoji: string
+    depositStatement: number
+    goalStatus: GoalStatus
+    progression: number
+    createdAt: string
+    updatedAt: string
+  }
+  

--- a/utils/fn/getRandomColor.ts
+++ b/utils/fn/getRandomColor.ts
@@ -1,0 +1,9 @@
+
+
+const getRandomColor = () => {
+    const list: string[] = ["F06C8A", "FD618C66", "BADBFF"]
+
+    return "#" + list[Math.floor(Math.random() * list.length)]
+}
+
+export default getRandomColor


### PR DESCRIPTION
## 📝 Résumé

Ajout des objectifs coté parent. 

## 🔧 Type de changement

-   [ ] 🐛 Bug fix
-   [ ] ✨ Nouvelle fonctionnalité
-   [ ] 📚 Documentation
-   [ ] 🎨 Amélioration UI/UX
-   [ ] ♻️ Refactoring
-   [ ] ⚡ Performance

## 🧪 Tests effectués

-   [ ] Tests manuels sur iOS
-   [ ] Tests manuels sur Android
-   [ ] Tests des cas d'erreur

## 📱 Screenshots/Vidéos

<!-- Si changement UI, ajoutez des captures d'écran -->

## 🔗 Ticket JIRA

<!-- Lien vers le ticket associé : MB-XXX -->

## ✅ Checklist

-   [ ] Le code compile sans erreur
-   [ ] Pas de console.log oubliés
-   [ ] Code testé manuellement

## Summary by Sourcery

Add a dedicated goals screen for a child’s savings and wire it into the existing children flow.

New Features:
- Introduce a goals screen that lists a child’s savings goals with total saved amount and pull-to-refresh.
- Enable navigation from the child savings (Épargne) bubble to the new goals screen with the selected child prefilled.
- Add goal domain types, a goals API service, and reusable GoalCard and circular progress UI components for displaying goal progression.

Enhancements:
- Add a utility to generate random colors for goal cards.