### PR TITLE
add children budget page

### DIFF
--- a/app/(app)/budget/_layout.tsx
+++ b/app/(app)/budget/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function BudgetLayout() {
+	return (
+		<Stack screenOptions={{ headerShown: false }}>
+			<Stack.Screen name="index" />
+		</Stack>
+	);
+}

--- a/app/(app)/budget/index.tsx
+++ b/app/(app)/budget/index.tsx
@@ -1,0 +1,176 @@
+
+import ButtonsActionChildren from "@/components/ButtonsActionChildren";
+import TransactionList from "@/components/TransactionList";
+import { transactionService } from "@/services/transactionService";
+import { SubAccount } from "@/types/Account";
+import { Transaction } from "@/types/Transaction";
+import { UserStorage } from "@/utils/storage";
+import { useEffect, useState } from "react";
+import { StyleSheet, SafeAreaView, ScrollView, View, ActivityIndicator, Text, RefreshControl, Image } from "react-native"
+
+
+const BudgetPage = () => {
+    const [subAccount, setSubAccount] = useState<SubAccount | null>(null);
+    const [transactions, setTransactions] = useState<Transaction[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [refreshing, setRefreshing] = useState(false);
+
+    const loadData = async() => {
+        try {
+			const accountData = await UserStorage.getSubAccount();
+			setSubAccount(accountData);
+
+            if (accountData)
+                setTransactions(await transactionService.getTransactionsBySubAccount(accountData.id))
+
+		} catch (error) {
+			console.error("Error loading chapters:", error);
+		} finally {
+			setLoading(false);
+		}
+    } 
+
+	const onRefresh = async () => {
+		setRefreshing(true);
+		try {
+			await loadData();
+		} finally {
+			setRefreshing(false);
+		}
+	};
+
+    useEffect(() => {
+		loadData();
+	}, []);
+
+    if (loading || !subAccount) {
+        return (
+			<View style={[styles.container, styles.center]}>
+				<ActivityIndicator size="large" color="#6C5CE7" />
+				<Text style={styles.loadingText}>Chargement...</Text>
+			</View>
+		);
+    }
+
+
+    return (
+        <SafeAreaView style={styles.container}>
+            <ScrollView
+				style={styles.content}
+				showsVerticalScrollIndicator={false}
+				refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#6C5CE7" />}
+			>
+                {/* Content - Bank card */}
+                <View style={styles.bankCardContainer}>
+                    <View style={styles.bankCardHalf}>
+                        <View style={styles.column}>
+                            <Text style={styles.bankCardTitle}>Solde disponible</Text>
+                            <Text style={styles.bankCardSubTitle}>{Number(subAccount?.money)?.toFixed(2)}€</Text>
+                        </View>
+                        <View style={styles.column}>
+                            <Text style={styles.bankCardText}>{subAccount?.name}</Text>
+                            <Text style={styles.bankCardText}>••••  ••••  ••••  CASH</Text>
+                        </View>
+                    </View>
+                    <Image source={require('@/assets/images/reminder/image_8.png')} />
+                </View>
+
+                {/* Content - Buttons */}
+                <View style={styles.buttonsContainer}>
+                    <ButtonsActionChildren subAccount={subAccount} labelPosition="outside" addScan/>
+                </View>
+
+                {/* Content - Buttons bis */}
+
+
+                {/* Content - Transaction */}
+                <View style={{display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 12, marginVertical: 32,}}>
+                    <Text style={styles.title}>Dernières transactions</Text>
+                    <View style={[{width: "100%"}]}>
+                        <TransactionList transactions={transactions} lilList/>
+                    </View>
+                </View>
+            </ScrollView>
+        </SafeAreaView>
+    )
+}
+
+const styles = StyleSheet.create({
+    // Generic
+    column: {
+        display: "flex",
+        flexDirection: "column",
+        gap: 8
+    },
+    title: {
+        fontWeight: 700,
+        color: "#2F2F2F",
+        fontSize: 20
+    },  
+    // Container
+	container: {
+		flex: 1,
+		backgroundColor: "#ecf2fb"
+	},
+	content: {
+		flex: 1,
+        paddingHorizontal: 20,
+	},
+    // Loading
+    center: {
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	loadingText: {
+		marginTop: 12,
+		fontSize: 16,
+		color: "#666",
+	},
+    //Content - Bank card
+    bankCardContainer: {
+        marginTop: 12,
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "flex-end",
+        backgroundColor: "#846DED",
+        padding: 24,
+        borderRadius: 12,
+        shadowColor: "#BFD0EA",
+        shadowOffset: { width: 0, height: 6 },
+        shadowOpacity: 1,
+        shadowRadius: 0,
+        elevation: 4,
+    },
+    bankCardHalf: {
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        gap: 16
+    },
+    bankCardTitle: {
+        fontWeight: 700,
+        fontSize: 20,
+        color: "#FFFFFF",
+    },
+    bankCardSubTitle: {
+        fontWeight: 800,
+        fontSize: 40,
+        color: "#FFFFFF",
+    },
+    bankCardText: {
+        fontWeight: 400,
+        fontSize: 16,
+        color: "#FFFFFF",
+    },
+    // Content - Buttons
+    buttonsContainer: {
+        marginTop: 32,
+        backgroundColor: "#D1DEF1",
+        borderRadius: 8,
+        padding: 12
+    }
+
+})
+
+export default BudgetPage

--- a/app/(app)/transactions/_layout.tsx
+++ b/app/(app)/transactions/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function TransactionsLayout() {
+	return (
+		<Stack screenOptions={{ headerShown: false }}>
+			<Stack.Screen name="index" />
+		</Stack>
+	);
+}

--- a/app/(app)/transactions/index.tsx
+++ b/app/(app)/transactions/index.tsx
@@ -1,0 +1,128 @@
+import {SafeAreaView, ScrollView, StyleSheet, RefreshControl, View, Text, TouchableOpacity} from 'react-native'
+import {useEffect, useState} from 'react'
+import { UserStorage } from '@/utils/storage'
+import { SubAccount } from '@/types/Account';
+import { Transaction } from '@/types/Transaction';
+import { transactionService } from '@/services/transactionService';
+import TransactionList from '@/components/TransactionList';
+import { router } from 'expo-router';
+import { Ionicons } from "@expo/vector-icons";
+
+const TransactionsPage = () => {
+    const [subAccount, setSubAccount] = useState<SubAccount | null>(null);
+    const [transactions, setTransactions] = useState<Transaction[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [refreshing, setRefreshing] = useState<boolean>(false)
+
+
+    const loadData = async() => {
+        try {
+			const accountData = await UserStorage.getSubAccount();
+			setSubAccount(accountData);
+
+            if (accountData)
+                setTransactions(await transactionService.getTransactionsBySubAccount(accountData.id))
+
+		} catch (error) {
+			console.error("Error loading chapters:", error);
+		} finally {
+			setLoading(false);
+		}
+    } 
+
+    const onRefresh = async () => {
+		setRefreshing(true);
+		try {
+			await loadData();
+		} finally {
+			setRefreshing(false);
+		}
+	};
+
+    useEffect(() => {
+        loadData()
+    }, [])
+
+    return (
+        <SafeAreaView style={styles.container}>
+            <ScrollView
+                style={styles.content}
+                showsVerticalScrollIndicator={false}
+                refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#6C5CE7" />}
+            >
+
+                {/* Header */}
+                <View style={styles.header}>
+                    <TouchableOpacity style={styles.closeButton} onPress={() => router.back()}>
+                        <Ionicons name='arrow-back-sharp' size={24} color={"#FFFFFF"} />
+                    </TouchableOpacity>
+                    <View style={[{display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 8}]}>
+                        <View style={[{display: "flex", flexDirection: "row", alignItems: "flex-start", gap: 8}]}>
+                            <View style={[{borderRadius: 4, padding: 4, backgroundColor: "#E6E2FB"}]}><Ionicons name='wallet' size={20} color={"#846DED"} /></View>
+                            <Text style={styles.headerTitle}>Mes transactions</Text>
+                        </View>
+                        <Text style={styles.headerText}>{new Date().toLocaleString("fr-FR", { day: "2-digit", month: "long", year: "numeric"})}</Text>
+                    </View>
+                </View>
+
+                {/* Content */}
+                <View style={[styles.contentContainer]}>
+                    <TransactionList transactions={transactions} />
+                </View>
+
+            </ScrollView>
+        </SafeAreaView>
+    )
+}
+
+const styles = StyleSheet.create({
+    // Container
+	container: {
+		flex: 1,
+        backgroundColor: "#FFFFFF",
+	},
+	content: {
+		flex: 1,
+	},
+    // Header
+    header: {
+		flexDirection: "row",
+        gap: 16,
+		alignItems: "center",
+		paddingHorizontal: 20,
+		paddingTop: 10,
+		paddingBottom: 20,
+		borderBottomWidth: 1,
+		borderBottomColor: "#BFD0EA",
+	},
+	headerTitle: {
+		fontSize: 24,
+		fontWeight: "700",
+		color: "#2F2F2F",
+	},
+    headerText: {
+		fontSize: 14,
+		fontWeight: "700",
+		color: "#828282",
+	},
+	closeButton: {
+		backgroundColor: "#2F2F2F",
+        padding: 12,
+		borderRadius: 8,
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	closeButtonText: {
+		color: "#fff",
+		fontSize: 16,
+		fontWeight: "bold",
+	},
+    //Content
+    contentContainer: {
+        paddingHorizontal: 20,
+        paddingVertical: 20,
+        backgroundColor: "#ecf2fb",
+    }
+})
+
+export default TransactionsPage

--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -45,8 +45,8 @@ export const BottomNavigation: React.FC = () => {
 					iconNameActive: "home",
 				},
 				{
-					route: "/(app)/revenus",
-					label: "Revenus",
+					route: "/(app)/budget",
+					label: "Budget",
 					iconName: "wallet-outline",
 					iconNameActive: "wallet",
 				},
@@ -55,6 +55,12 @@ export const BottomNavigation: React.FC = () => {
 					label: "Tâches",
 					iconName: "checkmark-circle-outline",
 					iconNameActive: "checkmark-circle",
+				},
+				{
+					route: "/(app)/courses",
+					label: "Cours",
+					iconName: "book-outline",
+					iconNameActive: "book",
 				},
 				{
 					route: "/(app)/profile",

--- a/components/ButtonsActionChildren.tsx
+++ b/components/ButtonsActionChildren.tsx
@@ -1,0 +1,101 @@
+import { StyleSheet, TouchableOpacity, View, Text, Button } from "react-native"
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { router } from "expo-router";
+import ModalComponent from "./Modal";
+import SpendForm from "./forms/SpendForm";
+import { SubAccount } from "@/types/Account";
+
+enum ButtonType {
+    SPEND = 'SPEND',
+    SAVE = 'SAVE',
+    SCAN = 'SCAN'
+}
+
+const buttons = [
+    { type: ButtonType.SPEND, label: "Dépenser", iconName: "wallet", color: "#FD618C", shadowColor: "#D1325E"},
+    { type: ButtonType.SAVE, label: "Économiser", iconName: "wallet", color: "#846DED", shadowColor: "#4E31CF"},
+]
+const buttonWithScan = [...buttons, { type: ButtonType.SCAN, label: "Scanner", iconName: "wallet", color: "#16AA75", shadowColor: "#005C49"}]
+
+type IProps = {
+    subAccount: SubAccount
+    labelPosition?: "outside" | "inside"
+    addScan?: boolean
+}
+
+const ButtonsActionChildren = ({subAccount, labelPosition = "inside", addScan = false} : IProps) => {
+    const list = addScan ? buttonWithScan : buttons
+    const [showModal, setShowModal] = useState<ButtonType.SPEND | null>(null)
+
+    const handleButtonClick = (type: string) => {
+        if (type === ButtonType.SPEND)
+            setShowModal(ButtonType.SPEND)
+
+        if (type === ButtonType.SAVE)
+            router.push('/(app)/payment')
+
+        if (type === ButtonType.SCAN)
+            console.log(type)
+    }
+
+    return (
+        <>
+        {showModal === ButtonType.SPEND &&
+            <ModalComponent visible={showModal === ButtonType.SPEND} onClose={() => setShowModal(null)} backgroundColor="#FFFFFF">
+                <SpendForm subAccountId={subAccount.id}/>
+            </ModalComponent>
+        }
+
+        <View style={[styles.row, {paddingHorizontal: 8}]}>
+            {list.map((button) => (
+                <View style={styles.column} key={button.label}>
+                    <TouchableOpacity
+                        onPress={() => handleButtonClick(button.type)}
+                        style={[styles.button, {backgroundColor: button.color, shadowColor: button.shadowColor}]}
+                    >
+                        <Ionicons name={button.iconName as keyof typeof Ionicons.glyphMap} color={"#FFFFFF"} size={32}/>
+                        {labelPosition == "inside" && 
+                            <Text  style={[styles.labelText, {color: "#FFFFFF", fontSize: 16}]}>{button.label}</Text>}
+                    </TouchableOpacity>
+                    
+                    {labelPosition == "outside" && 
+                        <Text style={[styles.labelText, {color: "#2F2F2F", fontSize: 14}]}>{button.label}</Text>}
+                </View>
+            ))}
+        </View>
+        </>
+    )
+}
+
+const styles = StyleSheet.create({
+    row: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between"
+    },
+    column: {
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 8
+    },
+    button: {
+        display: "flex",
+        flexDirection: "row",
+        gap: 4,
+        alignItems: "center",
+        padding: 12,
+        borderRadius: 8,
+        shadowOffset: { width: 0, height: 6 },
+        shadowOpacity: 1,
+        shadowRadius: 0,
+        elevation: 4,
+    },
+    labelText: {
+        fontWeight: 700,
+    }
+})
+
+export default ButtonsActionChildren

--- a/components/TransactionList.tsx
+++ b/components/TransactionList.tsx
@@ -1,0 +1,132 @@
+import { Transaction, TransactionType } from "@/types/Transaction"
+import { StyleSheet, FlatList, View, Text, TouchableOpacity } from "react-native"
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+
+const GetIcon = ({transactionType}: {transactionType: TransactionType}) => {
+    const backgroundColor = transactionType === TransactionType.CREDIT ? "#9BFFE2" : "#FD618C"
+    const iconColor = transactionType === TransactionType.CREDIT ? "#16AA75" : "#D1325E"
+
+    return (
+        <View style={[styles.iconContainer, {backgroundColor}]}>
+            <Ionicons name={transactionType === TransactionType.CREDIT ? "wallet-outline" : "wallet-sharp"} color={iconColor} size={24}/>
+        </View>
+    )
+}
+
+const ButtonFullList = () => {
+
+    return (
+        <TouchableOpacity
+            onPress={() => router.push("/(app)/transactions")}
+            style={styles.buttonContainer}
+        >
+            <Text style={styles.buttonTitle}>Voir tout</Text>
+            <Ionicons name="arrow-forward" color={"#FFFFFF"} size={24}/>
+        </TouchableOpacity>
+    )
+}
+
+
+type IProps = {
+    transactions: Transaction[]
+    lilList?: boolean
+}
+
+const TransactionList = ({transactions, lilList = false}: IProps) => {
+    const transactionList = lilList ? transactions.slice(0, 4) : transactions
+
+    return (
+        <FlatList
+            scrollEnabled={false}
+            data={transactionList}
+            keyExtractor={transaction => transaction.id}
+            renderItem={({item, index}) => {
+                const isAdd = item.type === TransactionType.CREDIT
+                const radius = lilList && index === 0 
+                    ? {borderTopRightRadius: 8, borderTopLeftRadius: 8} 
+                    : lilList && transactionList?.length - 1 === index? {borderBottomRightRadius: 8, borderBottomLeftRadius: 8} 
+                    : lilList ? {} : {borderRadius: 8, marginTop: 8}
+
+                return (
+                    <View style={[styles.transactionFullContainer, radius]}>
+                        <View style={styles.transactionContainer}>
+                            <View style={{display: "flex", flexDirection: "row", alignItems: "center", gap: 8}}>
+                                <GetIcon transactionType={item.type}/>
+                                <View style={{display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 4}}>
+                                    <Text style={[styles.transactionTitle, {fontSize: 16, color: "2F2F2F"}]}>{item.description.substring(0, 18)}</Text>
+                                    <Text style={styles.transactionText}>{new Date(item.createdAt).toLocaleString("fr-FR", { day: "2-digit", month: "long", year: "numeric"})}</Text>
+                                </View>
+                            </View>
+                            <View>
+                                <Text  style={[styles.transactionTitle, {fontSize: 20, color: isAdd ? "#16AA75" : "#FD618C"}]}>
+                                    {isAdd ? "+" : "-"}{Number(item.amount).toFixed(2)}€
+                                </Text>
+                            </View>
+                        </View>
+                        {lilList && transactionList?.length - 1 === index && <ButtonFullList />}
+                    </View>
+                )
+            }}
+        />
+    )
+}
+
+const styles = StyleSheet.create({
+    transactionFullContainer: {
+        backgroundColor: "#FFFFFF",
+        padding: 12,
+        borderTopWidth: 1,
+        borderBottomWidth: 1,
+        borderColor: "#EBF2FB",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 24,
+        width: "100%"
+    },
+    transactionContainer: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        gap: 12,
+        alignItems: "center",
+        width: "100%"
+    },
+    transactionTitle: {
+        fontWeight: 700,
+    },
+    transactionText: {
+        fontWeight: 400,
+        fontSize: 14,
+        color: "#6E6E6E"
+    },
+    iconContainer: {
+        borderRadius: 4,
+        padding: 4
+    },
+    buttonContainer: {
+        backgroundColor: "#ACACAC",
+        padding: 12,
+        borderRadius: 12,
+        display: "flex",
+        flexDirection: "row",
+        gap: 12,
+        justifyContent: "center",
+        alignItems: "center",
+        shadowColor: "#6E6E6E",
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 1,
+        shadowRadius: 0,
+        elevation: 4,
+        width: "100%"
+    },
+    buttonTitle: {
+        fontWeight: 700,
+        fontSize: 16,
+        color: "#FFFFFF"
+    },
+})
+
+export default TransactionList

--- a/components/forms/SpendForm.tsx
+++ b/components/forms/SpendForm.tsx
@@ -1,0 +1,290 @@
+import getIconFromCategory, { categories } from "@/utils/fn/getIconFromCategory"
+import { useState } from "react"
+import { SafeAreaView, ScrollView, StyleSheet, View, Text, TextInput, TouchableOpacity, Alert } from "react-native"
+import { Ionicons } from "@expo/vector-icons"
+import DatePickerInput from "../DatePickerInput"
+import { moneyService } from "@/services/moneyService"
+
+
+type IProps = {
+    subAccountId: string
+}
+
+const SpendForm = ({subAccountId}: IProps ) => {
+    const [step, setStep] = useState<"Form" | "ValidateForm">("Form")
+
+    const [amount, setAmount] = useState<string>("0.00")
+    const [category, setCategory] = useState<string>(categories[0].value)
+    const [date, setDate] = useState<Date | null>(null)
+    const [details, setDetails] = useState<string>("")
+
+    const [loading, setLoading] = useState<boolean>(false)
+
+    const handleForm = async() => {
+        setLoading(true)
+        try {
+            await moneyService.addMoney({subAccountId, amount: Number(amount), description: details}, "false")
+            Alert.alert("Succès", "Dépense enregistré !", [{ text: "OK" }]);
+        } catch (error: any){
+            console.error("Error creating task:", error);
+			const errorMessage = error?.response?.data?.message || "Impossible d'enregistrer la dépense";
+			Alert.alert("Erreur", errorMessage);
+        } finally {
+            setLoading(false)
+        }
+    }
+
+
+    return (
+        <SafeAreaView style={[styles.container, {backgroundColor: step === "Form" ? "#FFFFFF" : "#ecf2fb"}]}>
+            <ScrollView
+                style={styles.content}
+                showsVerticalScrollIndicator={false}
+            >
+
+                {/* Content - First Step*/}
+                { step === "Form" && (
+                <View>
+                    {/* Montant affiché */}
+                    <View style={styles.customAmountContainer}>
+                        <TextInput
+                            style={[Number(amount) > 0 ? styles.customAmountInputSelected : styles.customAmountInputNonSelected]}
+                            value={amount}
+                            onChangeText={setAmount}
+                            keyboardType="decimal-pad"
+                            autoFocus
+                        />
+                        <Text style={styles.customAmountInputSelected}>€</Text>
+                    </View>
+
+                    {/* Expense type */}        
+                    <View style={styles.section}>
+                        <Text style={styles.sectionLabel}>Quel type de dépense est-ce-que c’est ?</Text>
+                        <View style={{display: "flex", flexDirection: "row", flexWrap: "wrap", gap: 12}}>
+                            {categories.map((cat, index) => {
+                                const selected = cat.value === category
+                                return (
+                                    <TouchableOpacity
+                                        key={`${cat.value}-${index}`}
+                                        onPress={() => setCategory(cat.value)}
+                                        style={[selected ? styles.categoryContainerSelected : styles.categoryContainer, {width: "22%"}]}
+                                    >
+                                        <Ionicons name={getIconFromCategory(cat.value) as keyof typeof Ionicons.glyphMap} size={24} color={selected ? "#2F2F2F" : "#6E6E6E"} />
+                                        <Text style={[selected ? styles.categoryLabelSelected : styles.categoryLabel]}>{cat.label}</Text>
+                                    </TouchableOpacity>
+                                )
+                            })}
+                        </View>
+                    </View>
+
+                    {/* Date Input */}
+                    <View style={styles.section}>
+                        <DatePickerInput 
+                            value={date}
+                            onChange={setDate}
+                            placeholder="Choisir une date de début"
+                        />
+                    </View>
+
+                
+                    {/* Date Input */}
+                    <View style={styles.section}>
+                        <Text style={styles.sectionLabel}>Détails</Text>
+                        <View style={styles.inputContainer}> 
+                            <TextInput
+                                placeholder="Ajoute un petit détail si tu veux !"
+                                autoCapitalize="sentences"
+                                value={details}
+                                onChangeText={setDetails}
+                                style={styles.textInput}
+                            />
+                            <Ionicons name="wallet" size={18} color="#979797" />
+                        </View>
+                    </View>
+                    
+                    {/* Footer - Button */}
+                    <View style={[styles.footer]}>
+                        <TouchableOpacity
+                            onPress={() => {Boolean(Number(amount) && category && date) && setStep('ValidateForm')}}
+                            style={[styles.button, Boolean(Number(amount) && category && date) ? styles.buttonSelected : {backgroundColor: "#D5D5D5"}, { width: "100%"}]}
+                            disabled={!Boolean(Number(amount) && category && date)}
+                        >
+                            <Text style={[styles.buttonText, {color: Boolean(Number(amount) && category && date) ? "#FFFFFF" : "#828282"} ]}>Enregistrer</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+                )}
+
+                {/* Content - First Step*/}
+                { step === "ValidateForm" && (
+                <View>
+                    {/* Summary */}
+                    <View>
+
+                    </View>
+
+                    {/* Footer - Button */}
+                    <View style={[styles.footer]}>
+                        <TouchableOpacity
+                            onPress={() => {setStep("Form")}}
+                            style={[styles.button, styles.buttonBack, {width: "24%"}]}
+                        >
+                            <Ionicons name="arrow-back" color={"#2F2F2F"} size={16}/>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            onPress={() => {handleForm()}}
+                            style={[styles.button, styles.buttonSelected, {width: "74%"} ]}
+                            disabled={!Boolean(Number(amount) && category && date)}
+                        >
+                            <Text style={[styles.buttonText, {color: "#FFFFFF"} ]}>Valider</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+                )}
+
+            </ScrollView>
+        </SafeAreaView>
+
+    )
+}
+
+const styles = StyleSheet.create({
+    // General
+    section: {
+        marginTop: 24,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+    },
+    sectionLabel: {
+        fontSize: 14,
+        fontWeight: "400",
+        color: "#2F2F2F",
+        marginBottom: 12,
+    },
+    // Container
+	container: {
+		flex: 1,
+	},
+	content: {
+		flex: 1,
+        paddingHorizontal: 20
+	},
+    // Content - Amount Input
+	customAmountContainer: {
+        display: "flex",
+		flexDirection: "row",
+        justifyContent: "center",
+		alignItems: "center",
+		backgroundColor: "#EBF2FB",
+		borderRadius: 4,
+        paddingVertical: 12,        
+		marginTop: 16,
+	},
+	customAmountInputNonSelected: {
+		fontSize: 40,
+		color: "#979797",
+        fontWeight: 800
+	},
+	customAmountInputSelected: {
+		fontSize: 40,
+		color: "#2F2F2F",
+		fontWeight: 800,
+	},
+    // Content - Expense type
+    categoryContainer: {
+        padding: 8,
+        borderRadius: 4,
+        borderWidth: 1.5,
+        borderColor: "#D5D5D5",
+        backgroundColor: "#EAEAEA",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    categoryContainerSelected: {
+        padding: 8,
+        borderRadius: 4,
+        borderWidth: 1.5,
+        borderColor: "#846DED",
+        backgroundColor: "#E6E2FB",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    categoryLabel: {
+        color: "#6E6E6E",
+        fontWeight: 400,
+        fontSize: 12
+    },
+    categoryLabelSelected: {
+        color: "#2F2F2F",
+        fontWeight: 600,
+        fontSize: 12
+    },
+    // Input
+    inputContainer: {
+		flexDirection: "row",
+		alignItems: "center",
+		backgroundColor: "#fff",
+		borderRadius: 8,
+		borderWidth: 1,
+		borderColor: "#D5D5D5",
+		paddingHorizontal: 16,
+	},
+    textInput: {
+		flex: 1,
+		fontSize: 16,
+		color: "#333",
+		paddingVertical: 16,
+	},
+    // Footer
+    footer: {
+		paddingBottom: 20,
+		paddingTop: 16,
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        width: "100%"
+	},
+    button: {
+        paddingVertical: 20,
+        paddingHorizontal: 24,
+        borderRadius: 8,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+    },
+    buttonSelected: {
+        backgroundColor: "#16AA75",
+        shadowColor: "#005C49",
+		shadowOffset: {
+			width: 0,
+			height: 4,
+		},
+		shadowOpacity: 1,
+		shadowRadius: 0,
+		elevation: 4,
+    },
+    buttonBack: {
+        backgroundColor: "#FFFFFF",
+        shadowColor: "#EBF2FB",
+		shadowOffset: {
+			width: 0,
+			height: 4,
+		},
+		shadowOpacity: 1,
+		shadowRadius: 0,
+		elevation: 4,
+    },
+    buttonText: {
+        fontWeight: 700,
+        fontSize: 20
+    }
+})
+
+
+
+export default SpendForm

--- a/services/moneyService.ts
+++ b/services/moneyService.ts
@@ -13,9 +13,9 @@ export interface AddMoneyResponse {
 }
 
 export const moneyService = {
-	async addMoney(data: AddMoneyRequest): Promise<AddMoneyResponse> {
+	async addMoney(data: AddMoneyRequest, isAdd = "true"): Promise<AddMoneyResponse> {
 		try {
-			await apiService.post("/money?isAdd=true", data);
+			await apiService.post(`/money?isAdd=${isAdd}`, data);
 			return { success: true };
 		} catch (error: any) {
 			logger.error("Error adding money:", error);

--- a/types/Transaction.ts
+++ b/types/Transaction.ts
@@ -1,8 +1,19 @@
+export enum TransactionType {
+	CREDIT = 'CREDIT',
+	DEBIT = "DEBIT"
+}
+
+export enum TransactionCategory {
+	COIN = 'COIN',
+	MONEY = "MONEY"
+}
+
 export interface Transaction {
 	id: string;
 	childId: string;
 	parentId: string;
-	type: "CREDIT" | "DEBIT";
+	type: TransactionType;
+	category: TransactionCategory
 	createdAt: string;
 	updatedAt: string;
 	amount: string;

--- a/utils/fn/getIconFromCategory.ts
+++ b/utils/fn/getIconFromCategory.ts
@@ -1,0 +1,24 @@
+
+export const categories: {value: string; label: string}[] = [
+    { value: "meal", label: "Repas" },
+    { value: "snack", label: "Goûter" },
+    { value: "games", label: "Jeux" },
+    { value: "clothing", label: "Vêtement" },
+    { value: "leisure", label: "Loisirs" },
+    { value: "reading", label: "Lecture" },
+    { value: "outing", label: "Sortie" },
+    { value: "gift", label: "Cadeau" },
+    { value: "transport", label: "Transport" },
+    { value: "school", label: "École" },
+    { value: "other", label: "Autre" }
+]
+
+const getIconFromCategory = (category: string): string => {
+
+    switch (category) {
+        default:
+            return "wallet"
+    }
+}
+
+export default getIconFromCategory


### PR DESCRIPTION
## 📝 Résumé

<!-- Décrivez brièvement ce que fait cette PR -->

## 🔧 Type de changement

-   [ ] 🐛 Bug fix
-   [ ] ✨ Nouvelle fonctionnalité
-   [ ] 📚 Documentation
-   [ ] 🎨 Amélioration UI/UX
-   [ ] ♻️ Refactoring
-   [ ] ⚡ Performance

## 🧪 Tests effectués

-   [ ] Tests manuels sur iOS
-   [ ] Tests manuels sur Android
-   [ ] Tests des cas d'erreur

## 📱 Screenshots/Vidéos

<!-- Si changement UI, ajoutez des captures d'écran -->

## 🔗 Ticket JIRA

<!-- Lien vers le ticket associé : MB-XXX -->

## ✅ Checklist

-   [ ] Le code compile sans erreur
-   [ ] Pas de console.log oubliés
-   [ ] Code testé manuellement

## Summary by Sourcery

Add a new child budget experience with spending and transaction views, and wire it into navigation.

New Features:
- Introduce a child budget page showing sub-account balance and recent transactions.
- Add a reusable transaction list component with support for compact and full views.
- Add a spending form and child action buttons to record expenses from a sub-account.
- Add dedicated screens and navigation stack for viewing all transactions.

Enhancements:
- Refine transaction typing with enums for type and category and update usages.
- Generalize money service addMoney API to support both credit and debit operations.
- Update bottom navigation to point to the new budget page and add a courses tab.