### PR TITLE
fix: add expo-build-properties to resolve CocoaPods modular headers c…

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,6 +42,17 @@
             "expo-apple-authentication",
             "expo-font",
             [
+                "expo-build-properties",
+                {
+                    "ios": {
+                        "extraPods": [
+                            { "name": "GoogleUtilities", "modular_headers": true },
+                            { "name": "RecaptchaInterop", "modular_headers": true }
+                        ]
+                    }
+                }
+            ],
+            [
                 "@react-native-google-signin/google-signin",
                 {
                     "iosUrlScheme": "com.googleusercontent.apps._some_id_here_"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "axios": "^1.9.0",
                 "expo": "~54.0.35",
                 "expo-apple-authentication": "~8.0.8",
+                "expo-build-properties": "^56.0.19",
                 "expo-constants": "~18.0.13",
                 "expo-dev-client": "~6.0.21",
                 "expo-font": "~14.0.12",
@@ -83,20 +84,20 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-            "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.5",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -246,14 +247,14 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.28.3"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -372,13 +373,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1566,6 +1567,153 @@
             "integrity": "sha512-6LYVmVGwjQvH+uzzWlVc9+oMj4lkNQ41aymVDjO+x8aFk8kCye20wOyLomYMZaMezA++Uf1mZRCw3W3Fy/hxEA==",
             "license": "MIT AND OFL-1.1"
         },
+        "node_modules/@expo/cli": {
+            "version": "54.0.25",
+            "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
+            "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
+            "license": "MIT",
+            "dependencies": {
+                "@0no-co/graphql.web": "^1.0.8",
+                "@expo/code-signing-certificates": "^0.0.6",
+                "@expo/config": "~12.0.13",
+                "@expo/config-plugins": "~54.0.4",
+                "@expo/devcert": "^1.2.1",
+                "@expo/env": "~2.0.8",
+                "@expo/image-utils": "^0.8.8",
+                "@expo/json-file": "^10.0.16",
+                "@expo/metro": "~54.2.0",
+                "@expo/metro-config": "~54.0.16",
+                "@expo/osascript": "^2.3.8",
+                "@expo/package-manager": "^1.9.10",
+                "@expo/plist": "^0.4.9",
+                "@expo/prebuild-config": "^54.0.8",
+                "@expo/schema-utils": "^0.1.8",
+                "@expo/spawn-async": "^1.7.2",
+                "@expo/ws-tunnel": "^1.0.1",
+                "@expo/xcpretty": "^4.3.0",
+                "@react-native/dev-middleware": "0.81.5",
+                "@urql/core": "^5.0.6",
+                "@urql/exchange-retry": "^1.3.0",
+                "accepts": "^1.3.8",
+                "arg": "^5.0.2",
+                "better-opn": "~3.0.2",
+                "bplist-creator": "0.1.0",
+                "bplist-parser": "^0.3.1",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.3.0",
+                "compression": "^1.7.4",
+                "connect": "^3.7.0",
+                "debug": "^4.3.4",
+                "env-editor": "^0.4.1",
+                "expo-server": "^1.0.7",
+                "freeport-async": "^2.0.0",
+                "getenv": "^2.0.0",
+                "glob": "^13.0.0",
+                "lan-network": "^0.2.1",
+                "minimatch": "^9.0.0",
+                "node-forge": "^1.3.3",
+                "npm-package-arg": "^11.0.0",
+                "ora": "^3.4.0",
+                "picomatch": "^4.0.3",
+                "pretty-bytes": "^5.6.0",
+                "pretty-format": "^29.7.0",
+                "progress": "^2.0.3",
+                "prompts": "^2.3.2",
+                "qrcode-terminal": "0.11.0",
+                "require-from-string": "^2.0.2",
+                "requireg": "^0.2.2",
+                "resolve": "^1.22.2",
+                "resolve-from": "^5.0.0",
+                "resolve.exports": "^2.0.3",
+                "semver": "^7.6.0",
+                "send": "^0.19.0",
+                "slugify": "^1.3.4",
+                "source-map-support": "~0.5.21",
+                "stacktrace-parser": "^0.1.10",
+                "structured-headers": "^0.4.1",
+                "tar": "^7.5.2",
+                "terminal-link": "^2.1.1",
+                "undici": "^6.18.2",
+                "wrap-ansi": "^7.0.0",
+                "ws": "^8.12.1"
+            },
+            "bin": {
+                "expo-internal": "build/bin/cli"
+            },
+            "peerDependencies": {
+                "expo": "*",
+                "expo-router": "*",
+                "react-native": "*"
+            },
+            "peerDependenciesMeta": {
+                "expo-router": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@expo/cli/node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@expo/cli/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@expo/cli/node_modules/semver": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@expo/cli/node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@expo/code-signing-certificates": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
@@ -1856,6 +2004,74 @@
                 "metro-symbolicate": "0.83.3",
                 "metro-transform-plugins": "0.83.3",
                 "metro-transform-worker": "0.83.3"
+            }
+        },
+        "node_modules/@expo/metro-config": {
+            "version": "54.0.16",
+            "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
+            "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.20.0",
+                "@babel/core": "^7.20.0",
+                "@babel/generator": "^7.20.5",
+                "@expo/config": "~12.0.13",
+                "@expo/env": "~2.0.8",
+                "@expo/json-file": "~10.0.16",
+                "@expo/metro": "~54.2.0",
+                "@expo/spawn-async": "^1.7.2",
+                "browserslist": "^4.25.0",
+                "chalk": "^4.1.0",
+                "debug": "^4.3.2",
+                "dotenv": "~16.4.5",
+                "dotenv-expand": "~11.0.6",
+                "getenv": "^2.0.0",
+                "glob": "^13.0.0",
+                "hermes-parser": "^0.29.1",
+                "jsc-safe-url": "^0.2.4",
+                "lightningcss": "^1.30.1",
+                "picomatch": "^4.0.3",
+                "postcss": "~8.4.32",
+                "resolve-from": "^5.0.0"
+            },
+            "peerDependencies": {
+                "expo": "*"
+            },
+            "peerDependenciesMeta": {
+                "expo": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+            "version": "10.0.16",
+            "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+            "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "~7.10.4",
+                "json5": "^2.2.3"
+            }
+        },
+        "node_modules/@expo/metro-config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/highlight": "^7.10.4"
+            }
+        },
+        "node_modules/@expo/metro-config/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@expo/metro-runtime": {
@@ -2212,6 +2428,39 @@
                 "@xmldom/xmldom": "^0.8.8",
                 "base64-js": "^1.2.3",
                 "xmlbuilder": "^15.1.1"
+            }
+        },
+        "node_modules/@expo/prebuild-config": {
+            "version": "54.0.8",
+            "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
+            "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
+            "license": "MIT",
+            "dependencies": {
+                "@expo/config": "~12.0.13",
+                "@expo/config-plugins": "~54.0.4",
+                "@expo/config-types": "^54.0.10",
+                "@expo/image-utils": "^0.8.8",
+                "@expo/json-file": "^10.0.8",
+                "@react-native/normalize-colors": "0.81.5",
+                "debug": "^4.3.1",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.6.0",
+                "xml2js": "0.6.0"
+            },
+            "peerDependencies": {
+                "expo": "*"
+            }
+        },
+        "node_modules/@expo/prebuild-config/node_modules/semver": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@expo/require-utils": {
@@ -2849,9 +3098,9 @@
             }
         },
         "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -2880,9 +3129,9 @@
             }
         },
         "node_modules/@react-native/codegen/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -2965,9 +3214,9 @@
             }
         },
         "node_modules/@react-native/dev-middleware/node_modules/ws": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-            "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+            "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
             "license": "MIT",
             "dependencies": {
                 "async-limiter": "~1.0.0"
@@ -3500,14 +3749,40 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/babel-jest": {
@@ -3780,9 +4055,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -4629,9 +4904,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -4773,6 +5048,53 @@
             "peerDependencies": {
                 "expo": "*",
                 "react-native": "*"
+            }
+        },
+        "node_modules/expo-asset": {
+            "version": "12.0.13",
+            "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+            "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@expo/image-utils": "^0.8.8",
+                "expo-constants": "~18.0.13"
+            },
+            "peerDependencies": {
+                "expo": "*",
+                "react": "*",
+                "react-native": "*"
+            }
+        },
+        "node_modules/expo-build-properties": {
+            "version": "56.0.19",
+            "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-56.0.19.tgz",
+            "integrity": "sha512-InoviXcxWosNp4cC7L3SWoiY99Xr2HdgN+LYHb6mUm/BBVxy1mIMrZR+3PJ2gwDZzW6EJNDz8ioASWGHBTmzpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@expo/schema-utils": "^56.0.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.6.0"
+            },
+            "peerDependencies": {
+                "expo": "*"
+            }
+        },
+        "node_modules/expo-build-properties/node_modules/@expo/schema-utils": {
+            "version": "56.0.1",
+            "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-56.0.1.tgz",
+            "integrity": "sha512-CZ/+mYbQmWeOnkCGlWy9K+lFxbJSMFY7+TqBZcKzBSTU5Q7IGRvn/sOG3TdNjIdLPmbA8xe7R/c3UUQ28R9i9w==",
+            "license": "MIT"
+        },
+        "node_modules/expo-build-properties/node_modules/semver": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/expo-constants": {
@@ -5200,170 +5522,6 @@
                 "expo": "*"
             }
         },
-        "node_modules/expo/node_modules/@expo/cli": {
-            "version": "54.0.25",
-            "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
-            "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
-            "license": "MIT",
-            "dependencies": {
-                "@0no-co/graphql.web": "^1.0.8",
-                "@expo/code-signing-certificates": "^0.0.6",
-                "@expo/config": "~12.0.13",
-                "@expo/config-plugins": "~54.0.4",
-                "@expo/devcert": "^1.2.1",
-                "@expo/env": "~2.0.8",
-                "@expo/image-utils": "^0.8.8",
-                "@expo/json-file": "^10.0.16",
-                "@expo/metro": "~54.2.0",
-                "@expo/metro-config": "~54.0.16",
-                "@expo/osascript": "^2.3.8",
-                "@expo/package-manager": "^1.9.10",
-                "@expo/plist": "^0.4.9",
-                "@expo/prebuild-config": "^54.0.8",
-                "@expo/schema-utils": "^0.1.8",
-                "@expo/spawn-async": "^1.7.2",
-                "@expo/ws-tunnel": "^1.0.1",
-                "@expo/xcpretty": "^4.3.0",
-                "@react-native/dev-middleware": "0.81.5",
-                "@urql/core": "^5.0.6",
-                "@urql/exchange-retry": "^1.3.0",
-                "accepts": "^1.3.8",
-                "arg": "^5.0.2",
-                "better-opn": "~3.0.2",
-                "bplist-creator": "0.1.0",
-                "bplist-parser": "^0.3.1",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.3.0",
-                "compression": "^1.7.4",
-                "connect": "^3.7.0",
-                "debug": "^4.3.4",
-                "env-editor": "^0.4.1",
-                "expo-server": "^1.0.7",
-                "freeport-async": "^2.0.0",
-                "getenv": "^2.0.0",
-                "glob": "^13.0.0",
-                "lan-network": "^0.2.1",
-                "minimatch": "^9.0.0",
-                "node-forge": "^1.3.3",
-                "npm-package-arg": "^11.0.0",
-                "ora": "^3.4.0",
-                "picomatch": "^4.0.3",
-                "pretty-bytes": "^5.6.0",
-                "pretty-format": "^29.7.0",
-                "progress": "^2.0.3",
-                "prompts": "^2.3.2",
-                "qrcode-terminal": "0.11.0",
-                "require-from-string": "^2.0.2",
-                "requireg": "^0.2.2",
-                "resolve": "^1.22.2",
-                "resolve-from": "^5.0.0",
-                "resolve.exports": "^2.0.3",
-                "semver": "^7.6.0",
-                "send": "^0.19.0",
-                "slugify": "^1.3.4",
-                "source-map-support": "~0.5.21",
-                "stacktrace-parser": "^0.1.10",
-                "structured-headers": "^0.4.1",
-                "tar": "^7.5.2",
-                "terminal-link": "^2.1.1",
-                "undici": "^6.18.2",
-                "wrap-ansi": "^7.0.0",
-                "ws": "^8.12.1"
-            },
-            "bin": {
-                "expo-internal": "build/bin/cli"
-            },
-            "peerDependencies": {
-                "expo": "*",
-                "expo-router": "*",
-                "react-native": "*"
-            },
-            "peerDependenciesMeta": {
-                "expo-router": {
-                    "optional": true
-                },
-                "react-native": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
-            "version": "54.0.8",
-            "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
-            "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
-            "license": "MIT",
-            "dependencies": {
-                "@expo/config": "~12.0.13",
-                "@expo/config-plugins": "~54.0.4",
-                "@expo/config-types": "^54.0.10",
-                "@expo/image-utils": "^0.8.8",
-                "@expo/json-file": "^10.0.8",
-                "@react-native/normalize-colors": "0.81.5",
-                "debug": "^4.3.1",
-                "resolve-from": "^5.0.0",
-                "semver": "^7.6.0",
-                "xml2js": "0.6.0"
-            },
-            "peerDependencies": {
-                "expo": "*"
-            }
-        },
-        "node_modules/expo/node_modules/@expo/json-file": {
-            "version": "10.0.16",
-            "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
-            "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "~7.10.4",
-                "json5": "^2.2.3"
-            }
-        },
-        "node_modules/expo/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "node_modules/expo/node_modules/@expo/metro-config": {
-            "version": "54.0.16",
-            "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
-            "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.20.0",
-                "@babel/core": "^7.20.0",
-                "@babel/generator": "^7.20.5",
-                "@expo/config": "~12.0.13",
-                "@expo/env": "~2.0.8",
-                "@expo/json-file": "~10.0.16",
-                "@expo/metro": "~54.2.0",
-                "@expo/spawn-async": "^1.7.2",
-                "browserslist": "^4.25.0",
-                "chalk": "^4.1.0",
-                "debug": "^4.3.2",
-                "dotenv": "~16.4.5",
-                "dotenv-expand": "~11.0.6",
-                "getenv": "^2.0.0",
-                "glob": "^13.0.0",
-                "hermes-parser": "^0.29.1",
-                "jsc-safe-url": "^0.2.4",
-                "lightningcss": "^1.30.1",
-                "picomatch": "^4.0.3",
-                "postcss": "~8.4.32",
-                "resolve-from": "^5.0.0"
-            },
-            "peerDependencies": {
-                "expo": "*"
-            },
-            "peerDependenciesMeta": {
-                "expo": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/expo/node_modules/babel-preset-expo": {
             "version": "54.0.11",
             "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.11.tgz",
@@ -5407,36 +5565,6 @@
                 }
             }
         },
-        "node_modules/expo/node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/expo/node_modules/expo-asset": {
-            "version": "12.0.13",
-            "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
-            "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@expo/image-utils": "^0.8.8",
-                "expo-constants": "~18.0.13"
-            },
-            "peerDependencies": {
-                "expo": "*",
-                "react": "*",
-                "react-native": "*"
-            }
-        },
         "node_modules/expo/node_modules/expo-file-system": {
             "version": "19.0.23",
             "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.23.tgz",
@@ -5455,51 +5583,6 @@
             "peerDependencies": {
                 "expo": "*",
                 "react": "*"
-            }
-        },
-        "node_modules/expo/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/expo/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/expo/node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/exponential-backoff": {
@@ -5649,9 +5732,9 @@
             "license": "MIT"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -5675,16 +5758,16 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -7351,12 +7434,12 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -7859,9 +7942,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -8063,10 +8146,13 @@
             "license": "MIT"
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -8468,9 +8554,9 @@
             }
         },
         "node_modules/react-native/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -8508,9 +8594,9 @@
             }
         },
         "node_modules/react-native/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -8532,9 +8618,9 @@
             }
         },
         "node_modules/react-native/node_modules/ws": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-            "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+            "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
             "license": "MIT",
             "dependencies": {
                 "async-limiter": "~1.0.0"
@@ -8792,9 +8878,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -8823,9 +8909,9 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -9026,9 +9112,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -9421,9 +9507,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -9452,9 +9538,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -9645,9 +9731,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-            "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"
@@ -10171,9 +10257,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "7.5.11",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+            "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
@@ -10251,15 +10337,18 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
                 "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "axios": "^1.9.0",
         "expo": "~54.0.35",
         "expo-apple-authentication": "~8.0.8",
+        "expo-build-properties": "^56.0.19",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.21",
         "expo-font": "~14.0.12",


### PR DESCRIPTION
…onflict

Add modular_headers for GoogleUtilities and RecaptchaInterop to fix the AppCheckCore static library build error during iOS pod install.

## 📝 Résumé

<!-- Décrivez brièvement ce que fait cette PR -->

## 🔧 Type de changement

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 📚 Documentation
- [ ] 🎨 Amélioration UI/UX
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance

## 🧪 Tests effectués

- [ ] Tests manuels sur iOS
- [ ] Tests manuels sur Android
- [ ] Tests des cas d'erreur

## 📱 Screenshots/Vidéos

<!-- Si changement UI, ajoutez des captures d'écran -->

## 🔗 Ticket JIRA

<!-- Lien vers le ticket associé : MB-XXX -->

## ✅ Checklist

- [ ] Le code compile sans erreur
- [ ] Pas de console.log oubliés
- [ ] Code testé manuellement

## Summary by Sourcery

Configure Expo iOS build properties to resolve CocoaPods modular header conflicts for Google-related pods.

Bug Fixes:
- Fix iOS AppCheckCore static library build errors by enabling modular headers for GoogleUtilities and RecaptchaInterop via Expo build properties.

Build:
- Add expo-build-properties configuration in app.json to customize iOS CocoaPods extra pods.

Chores:
- Add expo-build-properties as a new project dependency.